### PR TITLE
Handle rate limit error and retry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+ACCESS_TOKEN=
+ORGANIZATION=jupiterone

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,27 +1,28 @@
 name: Build
-on: [push, pull_request]
+on: 
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [12.x]
-        os: [ubuntu-latest]
-
+    runs-on: ubuntu-latest
     steps:
       - id: setup-node
         name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 14.x
 
       - name: Check out code repository source code
         uses: actions/checkout@v2
 
       - name: Install dependencies
         run: yarn
+
+      - name: Run tests
+        run: yarn test:ci
 
       - name: Run build
         run: yarn build
@@ -31,17 +32,12 @@ jobs:
   release:
     needs: test
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [12]
-
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - name: Check out repo
         uses: actions/checkout@v2
@@ -57,9 +53,11 @@ jobs:
           then
             echo "Found version commit tag. Publishing."
             echo "publish=true" >> $GITHUB_ENV
+            echo "VERSION_NUM=`echo $(git describe --tags --abbrev=0 | sed -e "s/v//gI")`" >> $GITHUB_ENV
           else
             echo "Version commit tag not found. Not publishing."
           fi
+
       - name: Publish
         if: env.publish == 'true'
         env:
@@ -67,4 +65,28 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
           yarn
-          npm publish
+          yarn build
+          npm publish ./dist
+
+      - name: Get Version Changelog Entry
+        if: env.publish == 'true'
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          version: ${{ env.VERSION_NUM }}
+          path: ./CHANGELOG.md
+        continue-on-error: true
+
+      - name: Create Release
+        if: env.publish == 'true'
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.changelog_reader.outputs.version }}
+          release_name: Release ${{ steps.changelog_reader.outputs.version }}
+          body: ${{ steps.changelog_reader.outputs.changes }}
+          prerelease: ${{ steps.changelog_reader.outputs.status == 'prereleased' }}
+          draft: ${{ steps.changelog_reader.outputs.status == 'unreleased' }}
+        continue-on-error: true

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,11 +1,14 @@
 name: gitleaks
-
-on: [push,pull_request]
+on: 
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: gitleaks-action
-      uses: zricethezav/gitleaks-action@master
+      - uses: actions/checkout@v1
+      - name: gitleaks-action
+        uses: zricethezav/gitleaks-action@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added `429` response handling in NPM registry API calls to fetch package
+  metadata details
+
 ## 2.2.0 - 2021-07-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,86 +1,59 @@
-# graph-npm
+# JupiterOne Integration
 
-## Development Environment
+Learn about the data ingested, benefits of this integration, and how to use it
+with JupiterOne in the [integration documentation](docs/jupiterone.md).
+
+## Development
 
 ### Prerequisites
 
-You must have Node.JS installed to run this project. If you don't already have
-it installed, you can can download the installer
-[here](https://nodejs.org/en/download/). You can alternatively install Node.JS
-using a version manager like [fnm](https://github.com/Schniz/fnm) or
-[nvm](https://github.com/nvm-sh/nvm).
+1. Install [Node.js](https://nodejs.org/) using the
+   [installer](https://nodejs.org/en/download/) or a version manager such as
+   [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm).
+2. Install [`yarn`](https://yarnpkg.com/getting-started/install) or
+   [`npm`](https://github.com/npm/cli#installation) to install dependencies.
+3. Install dependencies with `yarn install`.
+4. Register an account in the system this integration targets for ingestion and
+   obtain API credentials.
+5. `cp .env.example .env` and add necessary values for runtime configuration.
 
-### Setup
+   When an integration executes, it needs API credentials and any other
+   configuration parameters necessary for its work (provider API credentials,
+   data ingestion parameters, etc.). The names of these parameters are defined
+   by the `IntegrationInstanceConfigFieldMap`in `src/config.ts`. When the
+   integration is executed outside the JupiterOne managed environment (local
+   development or on-prem), values for these parameters are read from Node's
+   `process.env` by converting config field names to constant case. For example,
+   `clientId` is read from `process.env.CLIENT_ID`.
 
-#### Installing dependencies
+   The `.env` file is loaded into `process.env` before the integration code is
+   executed. This file is not required should you configure the environment
+   another way. `.gitignore` is configured to to avoid commiting the `.env`
+   file.
 
-From the root of this project, run `npm install` to install dependencies. If you
-have `yarn` installed, you can install dependencies by running `yarn`.
+### Running the integration
 
-#### Loading credentials
+1. `yarn start` to collect data
+2. `yarn graph` to show a visualization of the collected data
+3. `yarn j1-integration -h` for additional commands
 
-Create a `.env` file at the root of this project and add environment variables
-to match what is in `src/instanceConfigFields.json`. The `.env` file is ignored
-by git, so you won't have to worry about accidentally pushing credentials.
+### Making Contributions
 
-Given this example configuration:
+Start by taking a look at the source code. The integration is basically a set of
+functions called steps, each of which ingests a collection of resources and
+relationships. The goal is to limit each step to as few resource types as
+possible so that should the ingestion of one type of data fail, it does not
+necessarily prevent the ingestion of other, unrelated data. That should be
+enough information to allow you to get started coding!
 
-```json
-{
-  "clientId": {
-    "type": "string"
-  },
-  "clientSecret": {
-    "type": "string",
-    "mask": true
-  }
-}
-```
+See the
+[SDK development documentation](https://github.com/JupiterOne/sdk/blob/main/docs/integrations/development.md)
+for a deep dive into the mechanics of how integrations work.
 
-You would provide a `.env` file like this:
+See [docs/development.md](docs/development.md) for any additional details about
+developing this integration.
 
-```bash
-CLIENT_ID="client-id"
-CLIENT_SECRET="supersecret"
-```
+### Changelog
 
-The snake cased environment variables will automatically be converted and
-applied to the camel cased configuration field. So for example, `CLIENT_ID` will
-apply to the `clientId` config field, `CLIENT_SECRET` will apply to
-`clientSecret`, and `MY_SUPER_SECRET_CONFIGURATION_VALUE` will apply to a
-`mySuperSecretConfigurationValue` configuration field.
-
-## Running the integration
-
-To start collecting data, run `yarn start` from the root of the project. This
-will load in your configuration and execute the steps stored in `src/steps`.
-
-## Project structure
-
-This is the expected project structure for running integrations.
-
-```
-src/
-  /instanceConfigFields.json
-  /validateInvocation.ts
-  /getStepStartStates.ts
-  steps/
-    exampleStep.ts
-    // add additional steps here
-```
-
-Each of the files listed above contribute to creating an
-[integration configuration](https://github.com/JupiterOne/integration-sdk/blob/master/docs/development.md#the-integration-framework).
-
-Additional files can be placed under `src` and referenced from each of the
-integration files.
-
-The template project hosted
-[here](https://github.com/JupiterOne/integration-sdk/tree/master/template)
-provides a simple example of how an integration can be setup.
-
-## Development Docs
-
-Please reference the `@jupiterone/integration-sdk`
-[development documentation](https://github.com/JupiterOne/integration-sdk/blob/master/docs/development.md)
-for more information on how to build integrations.
+The history of this integration's development can be viewed at
+[CHANGELOG.md](CHANGELOG.md).

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:env": "LOAD_ENV=1 yarn test",
     "test:ci": "yarn lint && yarn type-check && yarn test",
     "build": "tsc -p tsconfig.dist.json --declaration",
-    "prepush": "yarn lint && yarn type-check && jest --changedSince master",
+    "prepush": "yarn lint && yarn type-check && jest --changedSince main",
     "prepack": "yarn build"
   },
   "dependencies": {
@@ -30,11 +30,11 @@
     "libnpm": "^3.0.1"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-core": "^6.10.0",
-    "@jupiterone/integration-sdk-dev-tools": "^6.10.0",
-    "@jupiterone/integration-sdk-testing": "^6.10.0"
+    "@jupiterone/integration-sdk-core": "^8.1.2",
+    "@jupiterone/integration-sdk-dev-tools": "^8.1.2",
+    "@jupiterone/integration-sdk-testing": "^8.1.2"
   },
   "peerDependencies": {
-    "@jupiterone/integration-sdk-core": "^6.10.0"
+    "@jupiterone/integration-sdk-core": "^8.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prepack": "yarn build"
   },
   "dependencies": {
+    "@lifeomic/attempt": "^3.0.1",
     "libnpm": "^3.0.1"
   },
   "devDependencies": {

--- a/src/api/searchPackage.ts
+++ b/src/api/searchPackage.ts
@@ -1,8 +1,70 @@
 import libnpm from 'libnpm';
+
+import { IntegrationProviderAPIError } from '@jupiterone/integration-sdk-core';
+import { retry as attemptRetry, sleep } from '@lifeomic/attempt';
+
 import { Package } from '../types';
 
-const searchPackage = (packageName: string): Promise<Package[]> => {
-  return libnpm.search(packageName);
+type PackageSearchResult = {
+  packages: Package[] | undefined;
+  err: Error | undefined;
 };
 
-export default searchPackage;
+type HttpErrorGeneral = Error & {
+  headers: Record<string, string[]> & { 'retry-after': string };
+  statusCode: number; // 429
+  code: string; // "E429"
+  method: string;
+  uri: string;
+};
+
+/**
+ * Fetch package metadata details using the NPM registry `GET /-/v1/search`
+ * endpoint.
+ *
+ * The `retry-after` header provides the number of seconds to wait.
+ *
+ * @see https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md
+ */
+export async function searchPackage(
+  packageName: string,
+): Promise<PackageSearchResult> {
+  try {
+    return await attemptRetry(
+      async (): Promise<PackageSearchResult> => {
+        const packages = await libnpm.search(packageName);
+        return { packages, err: undefined };
+      },
+      {
+        timeout: 60 * 3 * 1000,
+        maxAttempts: 1,
+
+        handleError: async (err, context, options) => {
+          if (isHttpError(err)) {
+            if (err.statusCode === 429) {
+              const retryAfterSeconds = Number(err.headers['retry-after']);
+              if (retryAfterSeconds) {
+                await sleep(retryAfterSeconds * 1000);
+                return;
+              }
+            } else {
+              throw new IntegrationProviderAPIError({
+                cause: err,
+                endpoint: err.uri,
+                status: err.statusCode,
+                statusText: err.code,
+              });
+            }
+          }
+          throw err;
+        },
+      },
+    );
+  } catch (err) {
+    return { packages: undefined, err };
+  }
+}
+
+function isHttpError(err: Error | HttpErrorGeneral): err is HttpErrorGeneral {
+  return (err as HttpErrorGeneral).statusCode !== undefined;
+}

--- a/src/api/searchPackage.ts
+++ b/src/api/searchPackage.ts
@@ -37,7 +37,7 @@ export async function searchPackage(
       },
       {
         timeout: 60 * 3 * 1000,
-        maxAttempts: 1,
+        maxAttempts: 3,
 
         handleError: async (err, context, options) => {
           if (isHttpError(err)) {

--- a/src/steps/fetch-packages/index.ts
+++ b/src/steps/fetch-packages/index.ts
@@ -114,7 +114,7 @@ const fetchPackages: IntegrationStep<NpmIntegrationConfig> = {
     if (searchErrors.length) {
       throw new IntegrationError({
         code: 'NPM_API_ERROR',
-        message: `Completed processing ${packages.length} total packages; ${searchErrors.length} errors occurred (cause is first one)`,
+        message: `Completed processing ${packageEntities.length} total packages; ${searchErrors.length} errors occurred (cause is first one)`,
         cause: searchErrors[0],
         fatal: false,
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -688,6 +688,11 @@
   resolved "https://registry.yarnpkg.com/@lifeomic/attempt/-/attempt-3.0.0.tgz#75fecc204f8b0ac18b5363b4404bb32450f01859"
   integrity sha512-Ibk4Vfl46dSrhtH5fHsrTA4waAuyP7/qcr3uo0mO70azRc6LWgJILlMy3B1oOvyiN9jQcdqwsThaQkPKLiYKTg==
 
+"@lifeomic/attempt@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@lifeomic/attempt/-/attempt-3.0.1.tgz#a1d65fc06df3b5650cc851a6cafee0a733f8b58e"
+  integrity sha512-zvQ6ydPI2mevhuZ++l2S93+DS08w27ad942Ae9WW5h7j+giEHrK7rsgbchVTAs0jo35Ox90G5/c8ZDSz5vipWg==
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"


### PR DESCRIPTION
```
$ j1-integration collect
...
Step "fetch-org-packages" completed with status: success
Step "fetch-org-teams" completed with status: success
Step "fetch-org-users" completed with status: success
✨  Done in 273.84s.
```

When we run out of tries, the error looks like:
```
15:00:27.998Z ERROR Local: Error fetching package details (stepId=fetch-org-packages)
  Error: Provider API failed at https://registry.npmjs.org/-/v1/search?text=%40jupiterone%2Fgraph-knowbe4&size=20&from=0&quality=0.65&popularity=0.98&maintenance=0.5: 429 E429
      at Object.handleError (/Users/aiwilliams/Workspaces/j1/gh/graph-npm/src/api/searchPackage.ts:53:21)
      at onError (/Users/aiwilliams/Workspaces/j1/gh/graph-npm/node_modules/@lifeomic/attempt/dist/src/index.js:93:31)
      at /Users/aiwilliams/Workspaces/j1/gh/graph-npm/node_modules/@lifeomic/attempt/dist/src/index.js:133:29
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
  Caused by: Error: 429 Too Many Requests - GET https://registry.npmjs.org/-/v1/search?text=%40jupiterone%2Fgraph-knowbe4&size=20&from=0&quality=0.65&popularity=0.98&maintenance=0.5
      at /Users/aiwilliams/Workspaces/j1/gh/graph-npm/node_modules/npm-registry-fetch/check-response.js:104:15
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

The code will keep working on packages even when one cannot be fetched. In the end, it fails execution of the step if there were any errors so that the collection is marked as `partial`; the synchronization system will not delete package entities from the graph.